### PR TITLE
Add support for multithread when downloading weights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ Dockerfile.cross
 *~
 .DS_Store
 artifacts
+cache
+
+__pycache__
+*.pyc

--- a/Dockerfile.loader
+++ b/Dockerfile.loader
@@ -7,8 +7,7 @@ RUN apk add --no-cache \
     libffi-dev \
     openssl-dev \
     py3-pip \
-    bash \
-    git
+    bash
 
 RUN pip install --no-cache-dir poetry
 

--- a/Makefile
+++ b/Makefile
@@ -188,9 +188,14 @@ image-push: image-build
 loader-image-build:
 	$(IMAGE_BUILD_CMD) -t $(LOADER_IMG) \
 		-f Dockerfile.loader \
-		$(PUSH) .
+		$(PUSH) \
+		$(LOAD) \
+		$(IMAGE_BUILD_EXTRA_OPTS) ./
 loader-image-push: PUSH=--push
 loader-image-push: loader-image-build
+
+loader-image-load: LOAD=--load
+loader-image-load: loader-image-build
 
 KIND = $(shell pwd)/bin/kind
 .PHONY: kind

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - **Scaling Efficiency (WIP)**: llmaz works smoothly with autoscaling components like [Cluster-Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) or [Karpenter](https://github.com/kubernetes-sigs/karpenter) to support elastic scenarios.
 - **Accelerator Fungibility (WIP)**: llmaz supports serving the same LLM with various accelerators to optimize cost and performance.
 - **SOTA Inference (WIP)**: llmaz supports the latest cutting-edge researches like [Speculative Decoding](https://arxiv.org/abs/2211.17192) or [Splitwise](https://arxiv.org/abs/2311.18677) to run on Kubernetes.
-- **Multi-host Support**: llmaz supports both single-host and multi-hosts scenarios with [LWS](https://github.com/kubernetes-sigs/lws) from day 1.
+- **Multi-hosts Support**: llmaz supports both single-host and multi-hosts scenarios with [LWS](https://github.com/kubernetes-sigs/lws) from day 1.
 
 ## Quick Start
 

--- a/config/crd/bases/inference.llmaz.io_services.yaml
+++ b/config/crd/bases/inference.llmaz.io_services.yaml
@@ -111,8 +111,10 @@ spec:
               workloadTemplate:
                 description: |-
                   WorkloadTemplate defines the underlying workload layout and configuration.
-                  Note: the LWS spec might be twisted to support different technologies
-                  like splitwise and accelerator fungibility and several LWSs will be created.
+                  Note: the LWS spec might be twisted with various LWS instances to support
+                  accelerator fungibility or other cutting-edge researches.
+                  LWS supports both single-host and multi-host scenarios, for single host
+                  cases, only need to care about replicas, rolloutStrategy and workerTemplate.
                 properties:
                   leaderWorkerTemplate:
                     description: LeaderWorkerTemplate defines the template for leader/worker

--- a/llmaz/main.py
+++ b/llmaz/main.py
@@ -18,7 +18,9 @@ import os
 import logging
 from datetime import datetime
 
+
 from loader.model_hub.hub_factory import HubFactory
+from loader.model_hub.huggingface import HUGGING_FACE
 
 logging.basicConfig(
     level=logging.INFO,
@@ -32,16 +34,16 @@ def get_env_variable(var_name):
     if it does not exist.
     """
     try:
-        return os.environ[var_name]
+        return os.getenv(var_name, HUGGING_FACE)
     except KeyError:
         raise EnvironmentError(f"Environment variable '{var_name}' not found.")
 
 
 if __name__ == "__main__":
-    start_time = datetime.now()
     hub_name = get_env_variable("MODEL_HUB_NAME")
     model_id = get_env_variable("MODEL_ID")
     hub = HubFactory.new(hub_name)
-    hub.load_model(model_id)
 
+    start_time = datetime.now()
+    hub.load_model(model_id)
     logger.info(f"loading models takes {datetime.now() - start_time}s")

--- a/pkg/configs.go
+++ b/pkg/configs.go
@@ -17,7 +17,7 @@ limitations under the License.
 package pkg
 
 const (
-	LOADER_IMAGE = "inftyai/model-loader:v0.0.1"
+	LOADER_IMAGE = "inftyai/model-loader:v0.0.2"
 
 	HOST_MODEL_PATH             = "/cache/models/"
 	CONTAINER_MODEL_PATH        = "/workspace/models/"

--- a/pkg/controller/inference/playground_controller.go
+++ b/pkg/controller/inference/playground_controller.go
@@ -328,8 +328,8 @@ func setControllerReferenceForService(owner metav1.Object, saf *inferenceclientg
 func modelIdentifiers(model *coreapi.Model) (modelID string, trimmedModelName string) {
 	if model.Spec.DataSource.ModelID != nil {
 		// This model name should be aligned with model loader.
-		modelNames := strings.ReplaceAll(*model.Spec.DataSource.ModelID, "/", "--")
-		return *model.Spec.DataSource.ModelID, strings.ToLower(modelNames)
+		modelNames := "models--" + strings.ReplaceAll(*model.Spec.DataSource.ModelID, "/", "--")
+		return *model.Spec.DataSource.ModelID, modelNames
 	}
 	// TODO: handle other data source.
 	return "", ""


### PR DESCRIPTION
We should test the improvement once we support OCI registry

Discard the approach of rust language right now because the limitation is due to the cloud vendor NAT, like 200Mpbs ~= 25 MB/s. https://github.com/InftyAI/llmaz/pull/40