### PR TITLE
Add new conditions to Playground

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: inftyai/llmaz-test
-  newTag: 0901-04
+  newName: inftyai/llmaz
+  newTag: main

--- a/docs/examples/llamacpp/playground.yaml
+++ b/docs/examples/llamacpp/playground.yaml
@@ -1,11 +1,11 @@
 apiVersion: inference.llmaz.io/v1alpha1
 kind: Playground
 metadata:
-  name: qwen2-0-5b
+  name: qwen2-0--5b
 spec:
   replicas: 1
   modelClaim:
-    modelName: qwen2-0-5b-gguf
+    modelName: qwen2-0--5b-gguf
   backendConfig:
     name: llamacpp
     args:

--- a/pkg/controller/inference/service_controller.go
+++ b/pkg/controller/inference/service_controller.go
@@ -219,7 +219,7 @@ func setServiceCondition(service *inferenceapi.Service, workload *lws.LeaderWork
 			Type:    inferenceapi.ServiceAvailable,
 			Status:  metav1.ConditionTrue,
 			Reason:  "ServiceReady",
-			Message: "InferenceService is ready",
+			Message: "Inference Service is ready",
 		}
 		apimeta.SetStatusCondition(&service.Status.Conditions, condition)
 	} else {
@@ -227,7 +227,7 @@ func setServiceCondition(service *inferenceapi.Service, workload *lws.LeaderWork
 			Type:    inferenceapi.ServiceProgressing,
 			Status:  metav1.ConditionTrue,
 			Reason:  "ServiceInProgress",
-			Message: "InferenceService is progressing",
+			Message: "Inference Service is progressing",
 		}
 		apimeta.SetStatusCondition(&service.Status.Conditions, condition)
 
@@ -240,7 +240,7 @@ func setServiceCondition(service *inferenceapi.Service, workload *lws.LeaderWork
 			Type:    inferenceapi.ServiceAvailable,
 			Status:  metav1.ConditionFalse,
 			Reason:  "ServiceNotReady",
-			Message: "InferenceService not ready",
+			Message: "Waiting for leaderWorkerSet ready",
 		}
 		apimeta.SetStatusCondition(&service.Status.Conditions, new_condition)
 	}

--- a/test/e2e/suit_test.go
+++ b/test/e2e/suit_test.go
@@ -17,6 +17,7 @@ package e2e
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -81,6 +82,7 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).NotTo(BeNil())
 
 	readyForTesting(k8sClient)
+	Expect(os.Setenv("TEST_TYPE", "E2E")).Should(Succeed())
 })
 
 var _ = AfterSuite(func() {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	lws "sigs.k8s.io/lws/api/leaderworkerset/v1"
+)
+
+func UpdateLwsToReady(ctx context.Context, k8sClient client.Client, name, namespace string) {
+	gomega.Eventually(func() error {
+		workload := &lws.LeaderWorkerSet{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, workload); err != nil {
+			return err
+		}
+		condition := metav1.Condition{
+			Type:    string(lws.LeaderWorkerSetAvailable),
+			Status:  metav1.ConditionStatus(corev1.ConditionTrue),
+			Reason:  "AllGroupsReady",
+			Message: "All replicas are ready",
+		}
+
+		changed := apimeta.SetStatusCondition(&workload.Status.Conditions, condition)
+		if changed {
+			return k8sClient.Status().Update(ctx, workload)
+		}
+		return nil
+	}, IntegrationTimeout, Interval).Should(gomega.Succeed())
+}
+
+func UpdateLwsToUnReady(ctx context.Context, k8sClient client.Client, name, namespace string) {
+	gomega.Eventually(func() error {
+		workload := &lws.LeaderWorkerSet{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, workload); err != nil {
+			return err
+		}
+		condition := metav1.Condition{
+			Type:    string(lws.LeaderWorkerSetAvailable),
+			Status:  metav1.ConditionStatus(corev1.ConditionFalse),
+			Reason:  "AllGroupsReady",
+			Message: "All replicas are ready",
+		}
+
+		changed := apimeta.SetStatusCondition(&workload.Status.Conditions, condition)
+		if changed {
+			return k8sClient.Status().Update(ctx, workload)
+		}
+		return nil
+	}, IntegrationTimeout, Interval).Should(gomega.Succeed())
+}

--- a/test/util/validation/validate_playground.go
+++ b/test/util/validation/validate_playground.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 
 	"github.com/google/go-cmp/cmp"
@@ -147,6 +148,15 @@ func ValidatePlayground(ctx context.Context, k8sClient client.Client, playground
 }
 
 func ValidatePlaygroundStatusEqualTo(ctx context.Context, k8sClient client.Client, playground *inferenceapi.Playground, conditionType string, reason string, status metav1.ConditionStatus) {
+	testType := os.Getenv("TEST_TYPE")
+	timeout := util.IntegrationTimeout
+	interval := util.Interval
+
+	if testType == "E2E" {
+		timeout = util.E2ETimeout
+		interval = util.E2EInterval
+	}
+
 	gomega.Eventually(func() error {
 		newPlayground := inferenceapi.Playground{}
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: playground.Name, Namespace: playground.Namespace}, &newPlayground); err != nil {
@@ -160,5 +170,5 @@ func ValidatePlaygroundStatusEqualTo(ctx context.Context, k8sClient client.Clien
 			}
 		}
 		return nil
-	}, util.E2ETimeout, util.E2EInterval).Should(gomega.Succeed())
+	}, timeout, interval).Should(gomega.Succeed())
 }

--- a/test/util/validation/validate_service.go
+++ b/test/util/validation/validate_service.go
@@ -196,8 +196,11 @@ func ValidateServiceStatusEqualTo(ctx context.Context, k8sClient client.Client, 
 		if condition := apimeta.FindStatusCondition(newService.Status.Conditions, conditionType); condition == nil {
 			return errors.New("condition not found")
 		} else {
-			if condition.Reason != reason || condition.Status != status {
-				return errors.New("reason or status not right")
+			if condition.Reason != reason {
+				return fmt.Errorf("reason not right, want %s, got %s", reason, condition.Reason)
+			}
+			if condition.Status != status {
+				return fmt.Errorf("status not right, want %s, got %s", status, string(condition.Status))
 			}
 		}
 		return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What this PR does / why we need it

For better observation and higher test coverage.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/InftyAI/llmaz/issues/117 https://github.com/InftyAI/llmaz/issues/113

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Once models haven't been created, `AbortProcessing` for model creation condition is emitted
```
