### PR TITLE
chore: add unit test in util package

### DIFF
--- a/pkg/util/uri.go
+++ b/pkg/util/uri.go
@@ -30,7 +30,7 @@ func ParseURI(uri string) (protocol string, address string, err error) {
 	return strings.ToUpper(parsers[0]), parsers[1], nil
 }
 
-// OSS address looks like: <bucket>.<endpoint>/<modelPath>
+// ParseOSS address looks like: <bucket>.<endpoint>/<modelPath>
 func ParseOSS(address string) (endpoint, bucket, modelPath string, err error) {
 	splits := strings.SplitN(address, ".", 2)
 	if len(splits) != 2 {

--- a/pkg/util/uri_test.go
+++ b/pkg/util/uri_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package util
 
-import "testing"
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
 
 func TestParseOSS(t *testing.T) {
 	testCases := []struct {
@@ -62,5 +66,53 @@ func TestParseOSS(t *testing.T) {
 				t.Fatal("unexpected result")
 			}
 		})
+	}
+}
+
+func TestParseURI(t *testing.T) {
+	tests := []struct {
+		name          string
+		uri           string
+		expectedProto string
+		expectedAddr  string
+		expectedErr   error
+	}{
+		{
+			name:          "valid uri with http",
+			uri:           "http://example.com",
+			expectedProto: "HTTP",
+			expectedAddr:  "example.com",
+			expectedErr:   nil,
+		},
+		{
+			name:          "invalid URI",
+			uri:           "invalid_uri",
+			expectedProto: "",
+			expectedAddr:  "",
+			expectedErr:   errors.New("uri format error"),
+		},
+		{
+			name:          "uri with incorrect format",
+			uri:           "missing-protocol",
+			expectedProto: "",
+			expectedAddr:  "",
+			expectedErr:   errors.New("uri format error"),
+		},
+	}
+
+	for _, test := range tests {
+		proto, addr, err := ParseURI(test.uri)
+
+		if proto != test.expectedProto {
+			t.Errorf("Test '%s' failed: Expected protocol %s, but got %s", test.name, test.expectedProto, proto)
+		}
+
+		if addr != test.expectedAddr {
+			t.Errorf("Test '%s' failed: Expected address %s, but got %s", test.name, test.expectedAddr, addr)
+		}
+
+		if !reflect.DeepEqual(err, test.expectedErr) {
+			t.Errorf("Test '%s' failed: Expected error %v, but got %v", test.name, test.expectedErr, err)
+		}
 	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -47,7 +47,7 @@ func MergeKVs(toMerge map[string]string, toBeMerged map[string]string) map[strin
 	return toMerge
 }
 
-// TODO: add unit tests.
+// In checks if a string is in a slice.
 func In(strings []string, s string) bool {
 	for _, str := range strings {
 		if str == s {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -113,3 +113,32 @@ func TestMergeKVs(t *testing.T) {
 		})
 	}
 }
+
+func TestIn(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		search   string
+		expected bool
+	}{
+		{
+			name:     "search for 'name1' in a list containing it",
+			input:    []string{"name1", "name2", "name3"},
+			search:   "name1",
+			expected: true,
+		},
+		{
+			name:     "search for 'name1' in a list without it",
+			input:    []string{"name2", "name3", "name4"},
+			search:   "name1",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		result := In(test.input, test.search)
+		if result != test.expected {
+			t.Fatalf("Test '%s' failed: For input %v and search %s, expected %t but got %t", test.name, test.input, test.search, test.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What this PR does / why we need it
- add unit test in util package
#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # part of https://github.com/InftyAI/llmaz/issues/156

#### Special notes for your reviewer
When I want to write test files for the project, I find that client.go convert.go is not very necessary to write test cases (not sure if it is correct). Because the convert.go code seems to be directly obtained from the k8s package.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
