### PR TITLE
Downsize model-loader image

### DIFF
--- a/Dockerfile.loader
+++ b/Dockerfile.loader
@@ -1,21 +1,31 @@
-FROM python:3.10-alpine
+FROM python:3.10-alpine as builder
 
 WORKDIR /workspace
+
+COPY pyproject.toml poetry.lock ./
+COPY llmaz/ llmaz/
+ENV POETRY_VIRTUALENVS_CREATE false
 
 RUN apk add --no-cache \
     build-base \
     libffi-dev \
     openssl-dev \
     py3-pip \
+    bash \
+    && pip install --no-cache-dir poetry && poetry install --no-dev
+
+
+FROM python:3.10-alpine
+
+WORKDIR /workspace
+
+RUN apk add --no-cache \
     bash
 
-RUN pip install --no-cache-dir poetry
+COPY --from=builder /workspace /workspace
+COPY --from=builder /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
+COPY --from=builder /usr/local/bin/ /usr/local/bin/
 
-RUN poetry config virtualenvs.create false
-COPY pyproject.toml poetry.lock .
-RUN poetry install --no-dev
-
-COPY llmaz/ llmaz/
 RUN mv llmaz/main.py main.py
 
-CMD ["poetry", "run", "python", "main.py"]
+CMD ["python", "main.py"]


### PR DESCRIPTION
#### What this PR does / why we need it
Downsize model-loader image

#### Which issue(s) this PR fixes
Fixes #

#### Special notes for your reviewer
1. We use a staged build and using the new dockerfile we see the image reduced from 470MB to 155MB.

<img width="959" alt="image" src="https://github.com/user-attachments/assets/f1e8e4bf-adc4-431e-802e-f73aeabb1d80">

2. We tested the old and new images and found that they can all start normally.
（1）the new image
<img width="911" alt="image" src="https://github.com/user-attachments/assets/86f1cec5-3690-4c8e-9ac4-fb4003ea64ee">
(2) the old image
<img width="957" alt="image" src="https://github.com/user-attachments/assets/4d086b72-9fd0-47ed-8eb2-914351b85e56">


#### Does this PR introduce a user-facing change?
