### PR TITLE
fix: fix some warnings when building images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-ARG BASE_IMAGE
-ARG BUILDER_IMAGE
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+ARG BUILDER_IMAGE=golang:1.23.0
 
 # Build the manager binary
-FROM ${BUILDER_IMAGE} as builder
-ARG TARGETOS
-ARG TARGETARCH
+FROM ${BUILDER_IMAGE} AS builder
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+ARG CGO_ENABLED=0
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -25,7 +26,7 @@ COPY client-go/ client-go/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.loader
+++ b/Dockerfile.loader
@@ -1,9 +1,9 @@
-FROM python:3.10-alpine as builder
+FROM python:3.10-alpine AS builder
 
 WORKDIR /workspace
 
 COPY pyproject.toml poetry.lock ./
-ENV POETRY_VIRTUALENVS_CREATE false
+ENV POETRY_VIRTUALENVS_CREATE=false
 
 RUN apk add --no-cache \
     build-base \

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ GIT_TAG ?= $(shell git describe --tags --dirty --always)
 IMG ?= $(IMAGE_REPO):$(GIT_TAG)
 BUILDER_IMAGE ?= golang:$(GO_VERSION)
 KIND_CLUSTER_NAME ?= kind
+CGO_ENABLED ?= 0
 
 LOADER_IMAGE_TAG ?= $(GIT_TAG)
 LOADER_IMAGE_REPO = inftyai/model-loader


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

There are some warnings when build image.
```
=> WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 5)                                                                   0.0s
=> WARN: InvalidDefaultArgInFrom: Default value for ARG ${BUILDER_IMAGE} results in empty or invalid base image name (line 5)                   0.0s
=> WARN: InvalidDefaultArgInFrom: Default value for ARG ${BASE_IMAGE} results in empty or invalid base image name (line 32)
```

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
