### PR TITLE
fix(env): ensure BackendRuntimeConfig.Envs overrides base Envs

### DIFF
--- a/pkg/controller/inference/playground_controller.go
+++ b/pkg/controller/inference/playground_controller.go
@@ -264,7 +264,7 @@ func buildTemplate(models []*coreapi.OpenModel, playground *inferenceapi.Playgro
 	// envs
 	envs := parser.Envs()
 	if playground.Spec.BackendRuntimeConfig != nil {
-		envs = append(envs, playground.Spec.BackendRuntimeConfig.Envs...)
+		envs = util.MergeEnvs(envs, playground.Spec.BackendRuntimeConfig.Envs)
 	}
 
 	// args

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -38,6 +38,27 @@ func MergeResources(toMerge corev1.ResourceList, toBeMerged corev1.ResourceList)
 	return toMerge
 }
 
+// MergeEnvs merges two env var list and ensures that entries in BackendRuntimeConfig.Env take precedence.
+// This function takes two slices of corev1.EnvVar: 'base' and 'overrides'. It returns a new slice of corev1.EnvVar
+// where the 'overrides' values overwrite any duplicate names in 'base'.
+func MergeEnvs(base []corev1.EnvVar, overrides []corev1.EnvVar) []corev1.EnvVar {
+	envMap := make(map[string]corev1.EnvVar)
+
+	for _, env := range base {
+		envMap[env.Name] = env
+	}
+
+	for _, env := range overrides {
+		envMap[env.Name] = env
+	}
+
+	result := make([]corev1.EnvVar, 0, len(envMap))
+	for _, env := range envMap {
+		result = append(result, env)
+	}
+	return result
+}
+
 // MergeKVs will merge kvs in toBeMerged to toMerge.
 // If kvs exist in toMerge, they will be replaced.
 func MergeKVs(toMerge map[string]string, toBeMerged map[string]string) map[string]string {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -71,6 +71,101 @@ func TestMergeResources(t *testing.T) {
 	}
 }
 
+func TestMergeEnvs(t *testing.T) {
+	testCases := []struct {
+		name      string
+		base      []corev1.EnvVar
+		overrides []corev1.EnvVar
+		want      []corev1.EnvVar
+	}{
+		{
+			name: "overrides should overwrite base",
+			base: []corev1.EnvVar{
+				{Name: "VAR1", Value: "value1"},
+				{Name: "VAR2", Value: "value2"},
+			},
+			overrides: []corev1.EnvVar{
+				{Name: "VAR2", Value: "new_value2"},
+				{Name: "VAR3", Value: "value3"},
+			},
+			want: []corev1.EnvVar{
+				{Name: "VAR1", Value: "value1"},
+				{Name: "VAR2", Value: "new_value2"},
+				{Name: "VAR3", Value: "value3"},
+			},
+		},
+		{
+			name: "base has exclusive keys",
+			base: []corev1.EnvVar{
+				{Name: "VAR1", Value: "value1"},
+			},
+			overrides: []corev1.EnvVar{
+				{Name: "VAR2", Value: "value2"},
+			},
+			want: []corev1.EnvVar{
+				{Name: "VAR1", Value: "value1"},
+				{Name: "VAR2", Value: "value2"},
+			},
+		},
+		{
+			name: "base is empty",
+			base: []corev1.EnvVar{},
+			overrides: []corev1.EnvVar{
+				{Name: "VAR1", Value: "value1"},
+				{Name: "VAR2", Value: "value2"},
+			},
+			want: []corev1.EnvVar{
+				{Name: "VAR1", Value: "value1"},
+				{Name: "VAR2", Value: "value2"},
+			},
+		},
+		{
+			name: "overrides is empty",
+			base: []corev1.EnvVar{
+				{Name: "VAR1", Value: "value1"},
+				{Name: "VAR2", Value: "value2"},
+			},
+			overrides: []corev1.EnvVar{},
+			want: []corev1.EnvVar{
+				{Name: "VAR1", Value: "value1"},
+				{Name: "VAR2", Value: "value2"},
+			},
+		},
+		{
+			name:      "both base and overrides are empty",
+			base:      []corev1.EnvVar{},
+			overrides: []corev1.EnvVar{},
+			want:      []corev1.EnvVar{},
+		},
+		{
+			name:      "both base and overrides are nil",
+			base:      nil,
+			overrides: nil,
+			want:      []corev1.EnvVar{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MergeEnvs(tc.base, tc.overrides)
+
+			gotMap := make(map[string]string)
+			for _, env := range got {
+				gotMap[env.Name] = env.Value
+			}
+
+			wantMap := make(map[string]string)
+			for _, env := range tc.want {
+				wantMap[env.Name] = env.Value
+			}
+
+			if diff := cmp.Diff(gotMap, wantMap); diff != "" {
+				t.Fatalf("unexpected envs: %s", diff)
+			}
+		})
+	}
+}
+
 func TestMergeKVs(t *testing.T) {
 	testCases := []struct {
 		name       string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What this PR does / why we need it
- `playground.Spec.BackendRuntimeConfig.Envs` is set by the user. There is a high probability that Envs is the same as `BackendRuntime.Spec.Envs`. We should use the overwrite method instead of just appending.
#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes None

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
