### PR TITLE
chore: adopt golangci-lint v2

### DIFF
--- a/.github/workflows/golang-workflow.yaml
+++ b/.github/workflows/golang-workflow.yaml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   golang-ci:
-    uses: kerthcet/github-workflow-as-kube/.github/workflows/workflow-golang-ci.yaml@v0.1.18
+    uses: kerthcet/github-workflow-as-kube/.github/workflows/workflow-golang-ci.yaml@v0.1.21

--- a/.github/workflows/kube-workflow-init.yaml
+++ b/.github/workflows/kube-workflow-init.yaml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   init:
-    uses: kerthcet/github-workflow-as-kube/.github/workflows/workflow-as-kubernetes-init.yaml@v0.1.18
+    uses: kerthcet/github-workflow-as-kube/.github/workflows/workflow-as-kubernetes-init.yaml@v0.1.21
     secrets:
       AGENT_TOKEN: ${{ secrets.AGENT_TOKEN }}

--- a/.github/workflows/kube-workflow.yaml
+++ b/.github/workflows/kube-workflow.yaml
@@ -19,6 +19,6 @@ on:
 
 jobs:
   event-handler:
-    uses: kerthcet/github-workflow-as-kube/.github/workflows/workflow-as-kubernetes.yaml@v0.1.18
+    uses: kerthcet/github-workflow-as-kube/.github/workflows/workflow-as-kubernetes.yaml@v0.1.21
     secrets:
       AGENT_TOKEN: ${{ secrets.AGENT_TOKEN }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,42 +1,47 @@
+version: "2"
 run:
-  timeout: 5m
   allow-parallel-runners: true
-
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "pkg/*"
-      linters:
-        - dupl
-        - lll
-    - path: "test/*"
-      linters:
-        - dupl
-        - lll
 linters:
-  disable-all: true
+  default: none
   enable:
+    - copyloopvar
     - dupl
     - errcheck
-    - copyloopvar
     - goconst
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
     - prealloc
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - lll
+        path: api/*
+      - linters:
+          - dupl
+          - lll
+        path: pkg/*
+      - linters:
+          - dupl
+          - lll
+        path: test/*
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ test-deploy-with-helm: kind-image-build
 	E2E_KIND_NODE_VERSION=$(E2E_KIND_NODE_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND=$(KIND) KUBECTL=$(KUBECTL) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMAGE_TAG=$(IMG) TAG=$(GIT_TAG) ./hack/test-deploy-with-helm.sh
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.64.8
+GOLANGCI_LINT_VERSION ?= v2.2.1
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\
@@ -161,6 +161,10 @@ lint: golangci-lint pythonci-lint
 .PHONY: lint-fix
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 	$(GOLANGCI_LINT) run --fix
+
+.PHONY: lint-config
+lint-config: golangci-lint ## Verify golangci-lint linter configuration
+	$(GOLANGCI_LINT) config verify
 
 ##@ Build
 

--- a/pkg/controller/inference/service_controller.go
+++ b/pkg/controller/inference/service_controller.go
@@ -106,7 +106,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			service.Spec.WorkloadTemplate.WorkerTemplate.Spec.SchedulerName = configs.SchedulerName
 		}
 
-		if err := r.Client.Update(ctx, service); err != nil {
+		if err := r.Update(ctx, service); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update service: %w", err)
 		}
 	}

--- a/pkg/controller_helper/backendruntime/backendruntime.go
+++ b/pkg/controller_helper/backendruntime/backendruntime.go
@@ -130,7 +130,7 @@ func renderFlags(flags []string, modelInfo map[string]string) ([]string, error) 
 			if !exists || replacement == "" {
 				return nil, fmt.Errorf("missing flag or the flag has format error: %s", flag)
 			}
-			value = strings.Replace(value, match[0], replacement, -1)
+			value = strings.ReplaceAll(value, match[0], replacement)
 		}
 
 		res = append(res, value)

--- a/pkg/controller_helper/modelsource/modelsource_test.go
+++ b/pkg/controller_helper/modelsource/modelsource_test.go
@@ -210,7 +210,7 @@ func TestInjectModelEnvVars(t *testing.T) {
 			for _, env := range container.Env {
 				envVarMap[*env.Name] = true
 				if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
-					if *env.ValueFrom.SecretKeyRef.LocalObjectReferenceApplyConfiguration.Name == tt.expectSecretRef {
+					if *env.ValueFrom.SecretKeyRef.Name == tt.expectSecretRef {
 						secretRefFound = true
 					}
 				}

--- a/pkg/util/convert.go
+++ b/pkg/util/convert.go
@@ -79,7 +79,7 @@ var (
 		mismatchDetection: parseBool(os.Getenv("KUBE_PATCH_CONVERSION_DETECTOR")),
 		comparison: conversion.EqualitiesOrDie(
 			func(a, b time.Time) bool {
-				return a.UTC() == b.UTC()
+				return a.UTC().Equal(b.UTC())
 			},
 		),
 	}

--- a/test/util/validation/validate_service.go
+++ b/test/util/validation/validate_service.go
@@ -292,9 +292,10 @@ func ValidateSkipModelLoader(model *coreapi.OpenModel, index int, template corev
 					envStrings = append(envStrings, modelSource.HUGGING_FACE_TOKEN_KEY, modelSource.HUGGING_FACE_HUB_TOKEN)
 				} else if model.Spec.Source.URI != nil {
 					protocol, _, _ := pkgUtil.ParseURI(string(*model.Spec.Source.URI))
-					if protocol == modelSource.S3 || protocol == modelSource.GCS {
+					switch protocol {
+					case modelSource.S3, modelSource.GCS:
 						envStrings = append(envStrings, modelSource.AWS_ACCESS_KEY_ID, modelSource.AWS_ACCESS_KEY_SECRET)
-					} else if protocol == modelSource.OSS {
+					case modelSource.OSS:
 						envStrings = append(envStrings, modelSource.OSS_ACCESS_KEY_ID, modelSource.OSS_ACCESS_KEY_SECRET)
 					}
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What this PR does / why we need it

This pull request bumps `golangci-lint` version to v2. The config has been migrated via `golangci-lint migrate` suggested in https://golangci-lint.run/product/migration-guide/.

For developers, they may have to remove the binary in `bin` first if it already exists before running `make lint`.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #462 

#### Special notes for your reviewer

https://github.com/kerthcet/github-workflow-as-kube/blob/61f946b54583a4cd632ce968b95aafc82d5aab73/.github/workflows/workflow-golang-ci.yaml#L12

The `golangci-lint` version defined in [kerthcet/github-workflow-as-kube](https://github.com/kerthcet/github-workflow-as-kube) may also need to be updated. However, I am unsure whether this would affect other repositories. /cc @kerthcet 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
